### PR TITLE
Setup Automated with Gitpod

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,0 +1,26 @@
+FROM gitpod/workspace-full:latest
+
+
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+ENV PATH /opt/conda/bin:$PATH
+
+RUN sudo apt-get install -y wget bzip2 ca-certificates \
+    libglib2.0-0 libxext6 libsm6 libxrender1 \
+    git mercurial subversion
+
+RUN wget --quiet https://repo.anaconda.com/archive/Anaconda3-5.3.0-Linux-x86_64.sh -O ~/anaconda.sh && \
+    sudo /bin/bash ~/anaconda.sh -b -p /opt/conda && \
+    sudo rm ~/anaconda.sh && \
+    sudo ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+    sudo echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
+    sudo echo "conda activate base" >> ~/.bashrc
+
+RUN sudo apt-get install -y curl grep sed dpkg && \
+    TINI_VERSION=`curl https://github.com/krallin/tini/releases/latest | grep -o "/v.*\"" | sed 's:^..\(.*\).$:\1:'` && \
+    curl -L "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}.deb" > tini.deb && \
+    sudo dpkg -i tini.deb && \
+    sudo rm tini.deb && \
+    sudo apt-get clean
+
+ENTRYPOINT [ "/usr/bin/tini", "--" ]
+CMD [ "/bin/bash" ]

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,10 @@
+image:
+  file: .gitpod.dockerfile
+tasks:
+- init: mkdir /home/gitpod/.jupyter &&
+        jupyter notebook password &&
+        cp /home/gitpod/.jupyter/jupyter_notebook_config.json ./jupyter_notebook_config.json
+  command: jupyter notebook --ip=0.0.0.0 --config=$(pwd)/jupyter_notebook_config.json
+
+ports:
+- port: 8888

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # <img src="https://github.com/GokuMohandas/practicalAI/blob/master/images/logo.png" width="200" />
 
 [![Colab](https://img.shields.io/badge/launch-Colab-orange.svg)](https://github.com/GokuMohandas/practicalAI#notebooks)
+[![Setup Automated](https://img.shields.io/badge/setup-automated-blue?logo=gitpod)](https://gitpod.io/#https://github.com/GokuMohandas/practicalAI)
 [![Binder](https://img.shields.io/badge/launch-Jupyter-45aaf2.svg)](https://mybinder.org/v2/gh/GokuMohandas/practicalAI/master)
 [![Kesci](https://img.shields.io/badge/Kesci-中文-cd201f.svg)](https://www.kesci.com/home/column/5c20e4c5916b6200104eea63)
 [![MIT](https://img.shields.io/badge/license-MIT-5eba00.svg)](https://github.com/GokuMohandas/practicalAI/blob/master/LICENSE)
@@ -56,3 +57,7 @@ Empowering you to use machine learning to get valuable insights from data.
 8. Click on `Propose changes`.
 
 <img src="https://raw.githubusercontent.com/GokuMohandas/practicalAI/master/images/commit.png">
+
+## Open in Gitpod
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/GokuMohandas/practicalAI)


### PR DESCRIPTION
Hey @GokuMohandas ,

I would like to add two config files through this repo which can automate the task of setting up a workspace on Gitpod. Gitpod is an online IDE for GitHub. This PR might help the contributors as well as the learners. The workspace is equipped with anaconda so everything is installed by default and you can edit and runt the jupyter notebooks with the Gitpod IDE.

You can give it a try with my fork of this [repo](https://gitpod.io/#https://github.com/anudeepreddy/practicalAI) 

![image](https://user-images.githubusercontent.com/6022231/65058353-c0d23e00-d991-11e9-9442-89ef2a26d669.png)

When you launch the workspace for the first time you will be asked to setup a password for the jupyter notebook through the command line and you can use the same password to login to jupyter notebooks for the future sessions.

I hope this PR proves to be a great help for the contributors and learners.

Thanks,
Anudeep Reddy :)