### PR TITLE
Dog subclass specifies species for user

### DIFF
--- a/notebooks/01_Python.ipynb
+++ b/notebooks/01_Python.ipynb
@@ -1652,8 +1652,8 @@
       },
       "source": [
         "class Dog(Pet):\n",
-        "    def __init__(self, species, name, breed):\n",
-        "        super().__init__(species, name)\n",
+        "    def __init__(self, breed, name):\n",
+        "        super().__init__('Dog', name)\n",
         "        self.breed = breed\n",
         "    \n",
         "    def __str__(self):\n",
@@ -1674,7 +1674,7 @@
         }
       },
       "source": [
-        "scooby = Dog(species=\"dog\", name=\"Scooby\", breed=\"Great Dane\")\n",
+        "scooby = Dog(breed=\"Great Dane\", name=\"Scooby\")\n",
         "print (scooby)"
       ],
       "execution_count": 0,


### PR DESCRIPTION
Since we know the species is "dog" for the Dog subclass of Pet, instead of having the user specify species='dog' in params, we will just have the Dog class fill that in for the user, simplifying the interface.   I also moved the 'breed' parameter in front of 'name', to fit a logical heirarchy - species -> breed -> name.